### PR TITLE
Fix: Double Audio

### DIFF
--- a/src/app/tab3/tab3.page.ts
+++ b/src/app/tab3/tab3.page.ts
@@ -315,6 +315,8 @@ export class Tab3Page implements OnInit{
     this.lyrics = 'Loading ....';
     if(this.player){
       this.player.stop();
+      this.player.unload();
+      this.player = null;
     }
     this.player = new Howl({
       src:[song.path],


### PR DESCRIPTION
I use the unload() method to prevent a multiples Audios
and make the Howls instace to null